### PR TITLE
Allow `range_loc` inside subscript expression `index`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1367,7 +1367,7 @@ module.exports = grammar({
       field('argument', $._trailing_expr),
       '[',
       choice(
-        field('index', $._expr),
+        field('index', $._range_loc),
         field('range', $.range_expr),
       ),
       ']',

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8277,7 +8277,7 @@
                 "name": "index",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "_expr"
+                  "name": "_range_loc"
                 }
               },
               {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -12424,6 +12424,10 @@
             "named": false
           },
           {
+            "type": "^",
+            "named": false
+          },
+          {
             "type": "assignment_expr",
             "named": true
           },

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -102,8 +102,8 @@ struct TSLanguage {
   const uint16_t *small_parse_table;
   const uint32_t *small_parse_table_map;
   const TSParseActionEntry *parse_actions;
-  const char **symbol_names;
-  const char **field_names;
+  const char * const *symbol_names;
+  const char * const *field_names;
   const TSFieldMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;
@@ -123,6 +123,7 @@ struct TSLanguage {
     unsigned (*serialize)(void *, char *);
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
+  const TSStateId *primary_state_ids;
 };
 
 /*


### PR DESCRIPTION
Allow this kind of subscript expression: `arr[^2]`.