### PR TITLE
Implement 0.6.0 change for enum associated values.

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -216,6 +216,7 @@ module.exports = grammar({
     )),
     _module_path: $ => repeat1($.module_resolution),
     path_ident: $ => seq(optional($._module_path), $.ident),
+    path_type_ident: $ => seq(optional($._module_path), $.type_ident),
     path_const_ident: $ => seq(optional($._module_path), $.const_ident),
     path_at_ident: $ => seq(optional($._module_path), $.at_ident),
     path_at_type_ident: $ => seq(optional($._module_path), $.at_type_ident),
@@ -432,7 +433,7 @@ module.exports = grammar({
     _struct_or_union: _ => choice('struct', 'union'),
 
     interface: $ => seq(
-      $.type_ident,
+      $.path_type_ident,
       optional($.generic_arguments),
     ),
     interface_impl: $ => seq('(', commaSep($.interface), ')'),

--- a/grammar.js
+++ b/grammar.js
@@ -506,7 +506,10 @@ module.exports = grammar({
 
     // Enum
     // -------------------------
-    enum_arg: $ => seq('(', commaSepTrailing1($.arg), ')'),
+    enum_arg: $ => choice(
+        seq('(', commaSepTrailing1($.arg), ')'),    // < 0.6.0
+        seq('=', '{', commaSepTrailing1($.arg),'}') // >= 0.6.0
+    ),
     enum_constant: $ => seq(
       field('name', $.const_ident),
       field('args', optional($.enum_arg)),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -730,6 +730,27 @@
         }
       ]
     },
+    "path_type_ident": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_module_path"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type_ident"
+        }
+      ]
+    },
     "path_const_ident": {
       "type": "SEQ",
       "members": [
@@ -2336,7 +2357,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "type_ident"
+          "name": "path_type_ident"
         },
         {
           "type": "CHOICE",
@@ -2925,52 +2946,111 @@
       ]
     },
     "enum_arg": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "STRING",
-          "value": "("
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "("
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "arg"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "arg"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": ")"
+            }
+          ]
         },
         {
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "arg"
+              "type": "STRING",
+              "value": "="
             },
             {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "arg"
-                  }
-                ]
-              }
+              "type": "STRING",
+              "value": "{"
             },
             {
-              "type": "CHOICE",
+              "type": "SEQ",
               "members": [
                 {
-                  "type": "STRING",
-                  "value": ","
+                  "type": "SYMBOL",
+                  "name": "arg"
                 },
                 {
-                  "type": "BLANK"
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "arg"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
                 }
               ]
+            },
+            {
+              "type": "STRING",
+              "value": "}"
             }
           ]
-        },
-        {
-          "type": "STRING",
-          "value": ")"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -9391,7 +9391,7 @@
           "named": true
         },
         {
-          "type": "type_ident",
+          "type": "path_type_ident",
           "named": true
         }
       ]
@@ -11221,6 +11221,25 @@
         },
         {
           "type": "module_resolution",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "path_type_ident",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "module_resolution",
+          "named": true
+        },
+        {
+          "type": "type_ident",
           "named": true
         }
       ]


### PR DESCRIPTION
Support changes comming in enums for 0.6.0 

Also fixes failing to parse interfaces with explicit module paths declarations in structs. Ex:
```
module game;
import core;
    
struct MyGame (core::Game) {
    int counter;
}
```

Reference #3 